### PR TITLE
Add additional location for xmlWriter

### DIFF
--- a/Lib/robofab/glifLib.py
+++ b/Lib/robofab/glifLib.py
@@ -346,7 +346,11 @@ def writeGlyphToString(glyphName, glyphObject=None, drawPointsFunc=None, writer=
 	proper PointPen methods to transfer the outline to the .glif file.
 	"""
 	if writer is None:
-		from xmlWriter import XMLWriter
+		try:
+			from xmlWriter import XMLWriter
+		except ImportError:
+			# try the other location
+			from fontTools.misc.xmlWriter import XMLWriter
 		aFile = StringIO()
 		writer = XMLWriter(aFile, encoding="UTF-8")
 	else:

--- a/Lib/robofab/glifLib2.py
+++ b/Lib/robofab/glifLib2.py
@@ -378,7 +378,11 @@ def writeGlyphToString(glyphName, glyphObject=None, drawPointsFunc=None, writer=
 	proper PointPen methods to transfer the outline to the .glif file.
 	"""
 	if writer is None:
-		from xmlWriter import XMLWriter
+		try:
+			from xmlWriter import XMLWriter
+		except ImportError:
+			# try the other location
+			from fontTools.misc.xmlWriter import XMLWriter
 		aFile = StringIO()
 		writer = XMLWriter(aFile, encoding="UTF-8")
 	else:


### PR DESCRIPTION
The GitHub version of FontTools moved the location of xmlWriter to
fontTools.misc. This checks both locations when importing it.