### PR TITLE
Fix import FontInfo from fonttools

### DIFF
--- a/Lib/robofab/tools/toolsAll.py
+++ b/Lib/robofab/tools/toolsAll.py
@@ -66,7 +66,7 @@ def extractTTFFontInfo(font):
 	attrs = [
 			('copyright', 0),
 			('familyName', 1),
-			('fontStyle', 1),
+			('styleMapStyleName', 2),
 			('postscriptFullName', 4),
 			('trademark', 7),
 			('openTypeNameDesigner', 9),
@@ -79,12 +79,15 @@ def extractTTFFontInfo(font):
 	info.descender = font['hhea'].descent
 	info.unitsPerEm = font['head'].unitsPerEm
 	for name, index in attrs:
-		entry = font["name"].getName(index, 3, 1)
+		entry = font["name"].getName(index, 3, 1, 0x409)
 		if entry is not None:
 			try:
-				setattr(info, name, unicode(entry.string, "utf16"))
-			except:
-				print "Error importing value %s: %s"%(str(name), str(info))
+				value = unicode(entry.string, "utf_16_be")
+				if name == "styleMapStyleName":
+					value = value.lower()
+				setattr(info, name, value)
+			except Exception, e:
+				print "Error importing value %s: %s: %s"%(str(name), value, e.message)
 	return info
 
 def extractT1FontInfo(font):


### PR DESCRIPTION
Many bug fixes in this function:

  - Rename from deprecated fontStyle to styleMapStyleName,
  - Fix OpenType nameID for fontStyle; was 1, should be 2,
  - Lowercase style name such that "Regular" is accepted,
  - Request English names, otherwise we get arbitrary language,
  - Correctly decode strings as UTF-16BE, not UTF-16,
  - Improve error reporting.

It's not perfect, but at least loads regular fonts without error.