### PR TITLE
[filenames] fix NameError

### DIFF
--- a/Lib/ufoLib/filenames.py
+++ b/Lib/ufoLib/filenames.py
@@ -10,6 +10,11 @@ reservedFileNames = "CON PRN AUX CLOCK$ NUL A:-Z: COM1".lower().split(" ")
 reservedFileNames += "LPT1 LPT2 LPT3 COM2 COM3 COM4".lower().split(" ")
 maxFileNameLength = 255
 
+
+class NameTranslationError(Exception):
+	pass
+
+
 def userNameToFileName(userName, existing=[], prefix="", suffix=""):
 	"""
 	existing should be a case-insensitive list


### PR DESCRIPTION
a custom 'NameTranslationError' exception is used in handleClash2 function, but this is not defined in the module, and could raise NameError.