### PR TITLE
Add __ne__ comparison to BaseGlyph

### DIFF
--- a/Lib/robofab/objects/objectsBase.py
+++ b/Lib/robofab/objects/objectsBase.py
@@ -1322,6 +1322,9 @@ class BaseGlyph(RBaseObject):
 		if isinstance(other, BaseGlyph):
 			return self._getDigest() == other._getDigest()
 		return False
+	
+	def __ne__(self, other):
+		return not self.__eq__(other)
 
 	def _getDigest(self, pointsOnly=False):
 		"""Calculate a digest of coordinates, points, things in this glyph.


### PR DESCRIPTION
Only the == comparison operator was implemented for BaseGlyph, this adds a != comparison.