### PR TITLE
[objectsFL] fix RGroups.__delitem__

### DIFF
--- a/Lib/robofab/objects/objectsFL.py
+++ b/Lib/robofab/objects/objectsFL.py
@@ -2357,7 +2357,7 @@ class RGroups(BaseGroups):
 			
 	def __delitem__(self, key):
 		# override baseclass so that data is stored in FL classes
-		super(RGroups, self).__delitem__(key, value)
+		super(RGroups, self).__delitem__(key)
 		self._setFLGroups()
 		
 	def _setFLGroups(self):


### PR DESCRIPTION
I know `objectsFL.py` is no longer a priority, but anyway.

`__delitem__` method should only take one argument, `key`, not two `key` and `value` arguments.

The `pop` method still works as an alternative way to remove values from the groups dictionary.