### PR TITLE
objectsBase: set closed to False if firstType is MOVE to allow calling pen.endPath()

### DIFF
--- a/Lib/robofab/objects/objectsBase.py
+++ b/Lib/robofab/objects/objectsBase.py
@@ -1944,9 +1944,7 @@ class BaseContour(RBaseObject):
 			pen.qCurveTo(*pts)
 			pen.closePath()
 		else:
-			if firstType == MOVE and (firstOn.x, firstOn.y) == (lastOn.x, lastOn.y):
-				closed = True
-			elif firstType == MOVE:
+			if firstType == MOVE and (firstOn.x, firstOn.y) != (lastOn.x, lastOn.y):
 				closed = False
 			else:
 				closed = True

--- a/Lib/robofab/objects/objectsBase.py
+++ b/Lib/robofab/objects/objectsBase.py
@@ -1946,6 +1946,8 @@ class BaseContour(RBaseObject):
 		else:
 			if firstType == MOVE and (firstOn.x, firstOn.y) == (lastOn.x, lastOn.y):
 				closed = True
+			elif firstType == MOVE:
+				closed = False
 			else:
 				closed = True
 			for segment in self.segments:


### PR DESCRIPTION
whithout this, `pen.closePath()` is called all the time, even if the contour is not actually closed.

Fixes https://github.com/robofab-developers/robofab/issues/58.