### PR TITLE
World detection (ufo3k)

### DIFF
--- a/Lib/robofab/world.py
+++ b/Lib/robofab/world.py
@@ -46,23 +46,23 @@ class RFWorld:
 			self.applicationName = bundle.infoDictionary()["CFBundleName"]
 			self.inGlyphs = True
 			self.glyphsVersion = bundle.infoDictionary()["CFBundleVersion"]
-		except ImportError: pass
-		# are we in RoboFont
-		try:
-			import mojo
-			from AppKit import NSBundle
-			bundle = NSBundle.mainBundle()
-			self.applicationName = bundle.infoDictionary()["CFBundleName"]
-			self.inRoboFont = True
-			self.roboFontVersion = bundle.infoDictionary()["CFBundleVersion"]
-		except ImportError: pass
-		# are we in FontLab?
-		try:
-			from FL import fl
-			self.applicationName = fl.filename
-			self.inFontLab = True
-			self.flVersion = fl.version
-		except ImportError: pass
+		except ImportError:
+			# are we in RoboFont
+			try:
+				import mojo
+				from AppKit import NSBundle
+				bundle = NSBundle.mainBundle()
+				self.applicationName = bundle.infoDictionary()["CFBundleName"]
+				self.inRoboFont = True
+				self.roboFontVersion = bundle.infoDictionary()["CFBundleVersion"]
+			except ImportError:
+				# are we in FontLab?
+				try:
+					from FL import fl
+					self.applicationName = fl.filename
+					self.inFontLab = True
+					self.flVersion = fl.version
+				except ImportError: pass
 		# we are in NoneLab
 		if not self.inFontLab:
 			self.inPython = True

--- a/Lib/robofab/world.py
+++ b/Lib/robofab/world.py
@@ -38,13 +38,6 @@ class RFWorld:
 		self.inRoboFont = False
 		self.roboFontVersion = None
 
-		# are we in FontLab?
-		try:
-			from FL import fl
-			self.applicationName = fl.filename
-			self.inFontLab = True
-			self.flVersion = fl.version
-		except ImportError: pass
 		# are we in Glyphs?
 		try:
 			import objectsGS
@@ -62,6 +55,13 @@ class RFWorld:
 			self.applicationName = bundle.infoDictionary()["CFBundleName"]
 			self.inRoboFont = True
 			self.roboFontVersion = bundle.infoDictionary()["CFBundleVersion"]
+		except ImportError: pass
+		# are we in FontLab?
+		try:
+			from FL import fl
+			self.applicationName = fl.filename
+			self.inFontLab = True
+			self.flVersion = fl.version
 		except ImportError: pass
 		# we are in NoneLab
 		if not self.inFontLab:


### PR DESCRIPTION
I restructured the world detection code. The background is that there is a port of RoboFont's `mojo` for Glyphs, which in the old code would result in both `world.RFWorld().inGlyphs` and `world.RFWorld().inRoboFont` being set to `True`.