### PR TITLE
use repr() instead of str() to stringify float numbers

### DIFF
--- a/Lib/robofab/glifLib.py
+++ b/Lib/robofab/glifLib.py
@@ -362,7 +362,7 @@ def writeGlyphToString(glyphName, glyphObject=None, drawPointsFunc=None, writer=
 	if width is not None:
 		if not isinstance(width, (int, float)):
 			raise GlifLibError, "width attribute must be int or float"
-		writer.simpletag("advance", width=str(width))
+		writer.simpletag("advance", width=repr(width))
 		writer.newline()
 
 	unicodes = getattr(glyphObject, "unicodes", None)
@@ -666,8 +666,8 @@ class GLIFPointPen(AbstractPointPen):
 			for coord in pt:
 				if not isinstance(coord, (int, float)):
 					raise GlifLibError, "coordinates must be int or float"
-			attrs.append(("x", str(pt[0])))
-			attrs.append(("y", str(pt[1])))
+			attrs.append(("x", repr(pt[0])))
+			attrs.append(("y", repr(pt[1])))
 		if segmentType is not None:
 			attrs.append(("type", segmentType))
 		if smooth:
@@ -683,7 +683,7 @@ class GLIFPointPen(AbstractPointPen):
 			if not isinstance(value, (int, float)):
 				raise GlifLibError, "transformation values must be int or float"
 			if value != default:
-				attrs.append((attr, str(value)))
+				attrs.append((attr, repr(value)))
 		self.writer.simpletag("component", attrs)
 		self.writer.newline()
 

--- a/Lib/robofab/glifLib2.py
+++ b/Lib/robofab/glifLib2.py
@@ -394,7 +394,7 @@ def writeGlyphToString(glyphName, glyphObject=None, drawPointsFunc=None, writer=
 	if width is not None:
 		if not isinstance(width, (int, float)):
 			raise GlifLibError, "width attribute must be int or float"
-		writer.simpletag("advance", width=str(width))
+		writer.simpletag("advance", width=repr(width))
 		writer.newline()
 
 	unicodes = getattr(glyphObject, "unicodes", None)
@@ -695,8 +695,8 @@ class GLIFPointPen(AbstractPointPen):
 			for coord in pt:
 				if not isinstance(coord, (int, float)):
 					raise GlifLibError, "coordinates must be int or float"
-			attrs.append(("x", str(pt[0])))
-			attrs.append(("y", str(pt[1])))
+			attrs.append(("x", repr(pt[0])))
+			attrs.append(("y", repr(pt[1])))
 		if segmentType is not None:
 			attrs.append(("type", segmentType))
 		if smooth:
@@ -712,7 +712,7 @@ class GLIFPointPen(AbstractPointPen):
 			if not isinstance(value, (int, float)):
 				raise GlifLibError, "transformation values must be int or float"
 			if value != default:
-				attrs.append((attr, str(value)))
+				attrs.append((attr, repr(value)))
 		self.writer.simpletag("component", attrs)
 		self.writer.newline()
 


### PR DESCRIPTION
This fixes the same py23 issue as in the UFO3 glifLib: https://github.com/unified-font-object/ufoLib/issues/19

by the way, why is there a `glifLib2.py` module? What is it for?