### PR TITLE
[objectsFL] add missing 'clearContours' method to Fontlab's RGlyph

### DIFF
--- a/Lib/robofab/objects/objectsFL.py
+++ b/Lib/robofab/objects/objectsFL.py
@@ -1483,7 +1483,11 @@ class RGlyph(BaseGlyph):
 		position = int(round(position))
 		g = Guide(position, angle)
 		self._object.vguides.append(g)
-		
+
+	def clearContours(self):
+		self._object.Clear()
+		self._invalidateContours()
+
 	def clearComponents(self):
 		"""Clear all components."""
 		self._object.components.clean()


### PR DESCRIPTION
This is present in `robofab.objectsRF`, `defcon.objects.glyph` and in the new `fontParts.objects.base.glyph`.

However, for some reasons, it is missing from the `RGlyph` class inside `robofab.objectsFL` module.

It would be nice if we can have it there as well, so one can use the same piece of code to redraw a glyph's contours after clearing them out in all the different environments, both legacy and new.

I verified that the patch works on Fontlab 5. In fact, it doesn't add anything new but follows the general `clear` method from: https://github.com/robofab-developers/robofab/blob/master/Lib/robofab/objects/objectsFL.py#L1600-L1601

I cannot simply use `glyph.clear()` to get my cross-environment desired behavior because that has different signatures in each one (robofab, defcon, etc.) -- unless one just wants to clear *everything* inside a glyph; but I just want to clear contours.