### PR TITLE
[ufo3k] Remove ufoLib from packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setup(
 			"robofab.objects",
 			"robofab.pens",
 			"robofab.tools",
-                        "ufoLib",
 		],
 		package_dir = {'': 'Lib'},
 		#extra_path = 'FontTools',


### PR DESCRIPTION
This fixes an error on installing ufo3k branch. ufoLib files are already removed in #68.

```
$ pip install git+https://github.com/robofab-developers/robofab.git@ufo3k
Collecting git+https://github.com/robofab-developers/robofab.git@ufo3k
  Cloning https://github.com/robofab-developers/robofab.git (to ufo3k) to /var/folders/yc/x4nwgvvj3kz9pqm6pwnd91rh0000gn/T/pip-scaA38-build
    Complete output from command python setup.py egg_info:
    WARNING: '' not a valid package name; please use only .-separated package names in setup.py
    *** Warning: FontTools needs the numpy library for some operations, see:
            http://numpy.scipy.org/
    running egg_info
    creating pip-egg-info/robofab.egg-info
    writing pip-egg-info/robofab.egg-info/PKG-INFO
    writing top-level names to pip-egg-info/robofab.egg-info/top_level.txt
    writing dependency_links to pip-egg-info/robofab.egg-info/dependency_links.txt
    writing manifest file 'pip-egg-info/robofab.egg-info/SOURCES.txt'
    warning: manifest_maker: standard file '-c' not found

    error: package directory 'Lib/ufoLib' does not exist

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /var/folders/yc/x4nwgvvj3kz9pqm6pwnd91rh0000gn/T/pip-scaA38-build/
```
